### PR TITLE
Fix sales price parsing for non-breaking spaces and dollar signs

### DIFF
--- a/home_values/playwright_scraper.py
+++ b/home_values/playwright_scraper.py
@@ -92,7 +92,7 @@ def main():
                                 date = page.locator(f"table:nth-child(10) tr:nth-child({row}) td:nth-child(1) p").inner_text(timeout=2000)
                                 date_clean = int(date[-4:])
                                 sales_price = page.locator(f"table:nth-child(10) tr:nth-child({row}) td:nth-child(6) p").inner_text(timeout=2000)
-                                sales_price_clean = int(sales_price.replace(',', ''))
+                                sales_price_clean = int(sales_price.replace('\xa0', '').replace('$', '').replace(',', '').strip())
                                 if sales_price_clean > 150000 and date_clean not in sales_prices:
                                     sales_prices[date_clean] = sales_price_clean
                             except Exception as e:


### PR DESCRIPTION
## Summary
- Sales price scraping was failing with `invalid literal for int()` errors due to `\xa0` (non-breaking space) characters and `$` signs in the scraped HTML
- Updated line 95 in `playwright_scraper.py` to strip `\xa0`, `$`, commas, and whitespace before converting to `int()`

## Test plan
- [x] Run the scraper against addresses known to have sale prices
- [x] Confirm no `invalid literal for int()` errors appear in the output
- [x] Verify sale prices are correctly captured in `output.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)